### PR TITLE
Add compile workflow for GitHub

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,0 +1,28 @@
+name: Compile project
+
+on:
+  push:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get --no-install-recommends -y install guile-3.0-dev guile-3.0 guile-3.0-libs pkg-config make libsdl2-dev libsdl2-gfx-dev
+
+    - name: Compile
+      run: make
+
+    - name: Archive workflow results
+      uses: actions/upload-artifact@v2
+      with:
+        name: flux-compose
+        path: |
+          bin
+          !bin/**/*.o

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(OUT)/%.o: src/core/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
 
 $(OUT)/flux-compose: $(OBJ)
-	${CC} $(LIBS) -o bin/flux-compose $(OBJ)
+	${CC} -o bin/flux-compose $(OBJ) $(LIBS)
 
 $(OUT)/libflux.so:
 	$(MAKE) -C lib


### PR DESCRIPTION
This PR introduces a GitHub action for automatically building `flux-compose`. This ensures that other users can follow along later on their Debian-based distribution (or other `pkg-config`-compatible ones). 

You probably wants to adjust to the regular Schemers' environment, e.g. use Guix(-shell) instead, but I guess this is fine as a starting point.

For an example of the build job, see https://github.com/bkaestner/flux-compose/runs/4703776062?check_suite_focus=true