### PR TITLE
Fix compile errors warnings on macosx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,15 @@ find_package(Threads REQUIRED)
 
 # We could also use find_package(SDL), but that's only CMake 3.19
 pkg_check_modules(SDL2 REQUIRED IMPORTED_TARGET sdl2)
-pkg_check_modules(SDL2-Gfx REQUIRED IMPORTED_TARGET SDL2_gfx)
-pkg_check_modules(SDL2-Image REQUIRED IMPORTED_TARGET SDL2_image)
+pkg_check_modules(SDL2_GFX REQUIRED IMPORTED_TARGET SDL2_gfx)
+pkg_check_modules(SDL2_IMAGE REQUIRED IMPORTED_TARGET SDL2_image)
 
-include_directories(lib src)
+include_directories(lib src ${SDL2_INCLUDE_DIRS} ${SDL2_GFX_INCLUDE_DIRS}
+  ${SDL2_IMAGE_INCLUDE_DIRS})
 
 add_library(flux)
-target_link_libraries(flux PkgConfig::SDL2 PkgConfig::SDL2-Gfx
-  PkgConfig::SDL2-Image Threads::Threads)
+target_link_libraries(flux PkgConfig::SDL2 PkgConfig::SDL2_GFX
+  PkgConfig::SDL2_IMAGE Threads::Threads)
 
 add_executable(flux-compose)
 target_link_libraries(flux-compose flux)

--- a/lib/lib.c
+++ b/lib/lib.c
@@ -4,7 +4,7 @@
 #include <pthread.h>
 #include <SDL.h>
 #include <SDL2_gfxPrimitives.h>
-#include <SDL2/SDL_image.h>
+#include <SDL_image.h>
 
 #include "flux.h"
 #include "flux-internal.h"

--- a/lib/log.c
+++ b/lib/log.c
@@ -25,7 +25,7 @@ void flux_log_mem(void *ptr, const char *format, ...) {
   ENSURE_FP();
 
   // Prefix the line with the memory address
-  fprintf(log_file, "%x: ", ptr);
+  fprintf(log_file, "%p: ", ptr);
 
   va_list args;
   va_start(args, format);

--- a/lib/scene.c
+++ b/lib/scene.c
@@ -56,6 +56,8 @@ ValueHeader *flux_graphics_func_circle(VectorCursor *list_cursor, ValueCursor *v
 
   // TODO: Wrap this in a value type
   make_circle_struct(x, y, radius, color);
+
+  return NULL;
 }
 
 Uint32 scene_event_id = -1;

--- a/lib/script.c
+++ b/lib/script.c
@@ -346,6 +346,8 @@ ExprList *flux_script_parse_list(VectorCursor *token_cursor, VectorCursor *list_
 
   // At this point, assume we've reached TokenKindNone
   PARSE_LOG(list_cursor->current_item, "EXIT list parse\n");
+
+  return NULL;
 }
 
 Vector flux_script_parse(Vector token_vector) {
@@ -416,6 +418,9 @@ ValueHeader *flux_script_value_copy(ValueHeader *value, ValueCursor *value_curso
   case ValueKindString:
     EVAL_LOG(value, "Copying string \"%s\" to %x\n", ((ValueString *)value)->string, new_value);
     memcpy(new_value, value, sizeof(ValueString) + ((ValueString *)value)->length + 1);
+    break;
+  default:
+    /* nothing */
     break;
   }
 
@@ -503,6 +508,9 @@ ValueHeader *flux_script_eval_expr(ExprHeader *expr) {
       }
     } else {
       PANIC("Call expression has expr of kind %d in first position!\n", call_symbol->kind);
+  default:
+    /* nothing */
+    break;
     }
 
     return NULL;
@@ -531,5 +539,5 @@ ValueHeader *flux_script_eval(FILE *script_file) {
 
 ValueHeader *flux_script_eval_string(char *script_string) {
   FILE *stream = flux_file_from_string(script_string);
-  flux_script_eval(stream);
+  return flux_script_eval(stream);
 }

--- a/test/test-lang.c
+++ b/test/test-lang.c
@@ -4,9 +4,12 @@
 #include "test.h"
 #include "../lib/flux-internal.h"
 
+#define __stringify(s) str(s)
+#define str(s) #s
+
 #define ASSERT_KIND(_token, expected_kind)                                       \
   if (_token->kind != expected_kind) {                                           \
-    FAIL("Expected kind %d, got %s", #expected_kind, _token->kind);              \
+    FAIL("Expected kind %d, got %s", expected_kind, __stringify(_token->kind)); \
   }
 
 #define ASSERT_STR(expected, actual)                                             \

--- a/test/test.h
+++ b/test/test.h
@@ -31,7 +31,7 @@ extern char fail_message[2048];
 
 #define ASSERT_INT(expected, actual)                                            \
   if (actual != expected) {                                                     \
-    FAIL("Expected integer: %d\n                   got: %d\n               at line: %d\n", expected, actual, __LINE__); \
+    FAIL("Expected integer: %ld\n                   got: %ld\n               at line: %d\n", (long int) expected, (long int) actual, __LINE__); \
   }
 
 void test_vector_suite();

--- a/test/test.h
+++ b/test/test.h
@@ -25,7 +25,7 @@ extern char fail_message[2048];
 #define FAIL(message, ...)                                                     \
   tests_failed++;                                                              \
   printf("\e[1;91m  ✗ FAIL\e[0m %s\n", __func__);                              \
-  sprintf(fail_message, message __VA_OPT__(,) __VA_ARGS__);                    \
+  sprintf(fail_message, message, ##__VA_ARGS__);			       \
   printf("      %s\n\n", fail_message);                                        \
   return;
 


### PR DESCRIPTION
After these changes we can compile and run `flux-compose` on macOS too.