### PR TITLE
lib: fix build warnings on macOS

### DIFF
--- a/lib/font.c
+++ b/lib/font.c
@@ -127,7 +127,6 @@ FluxFont flux_font_load_file(const char *font_path, uint8_t font_size) {
 void flux_font_draw_text(FluxRenderContext context, FluxFont font, const char *text, float pos_x,
                          float pos_y) {
   float x, y;
-  char c = 0;
   uint8_t i = 0;
   uint8_t num_chars = 0;
   FluxFontChar *current_char = NULL;

--- a/lib/graphics.c
+++ b/lib/graphics.c
@@ -170,7 +170,7 @@ GLuint flux_graphics_shader_compile(const FluxShaderFile *shader_files, uint32_t
   return shader_program;
 }
 
-void flux_graphics_shader_mat4_set(uint shader_program_id, const char *uniform_name, mat4 matrix) {
+void flux_graphics_shader_mat4_set(unsigned int shader_program_id, const char *uniform_name, mat4 matrix) {
   unsigned int uniformLoc = glGetUniformLocation(shader_program_id, uniform_name);
   if (uniformLoc == -1) {
     PANIC("Could not find shader matrix parameter: %s\n", uniform_name);
@@ -273,7 +273,6 @@ void flux_graphics_draw_args_center(FluxDrawArgs *args, bool centered) {
 
 void flux_graphics_draw_texture_ex(FluxRenderContext context, FluxTexture texture, float x, float y,
                                    FluxDrawArgs *args) {
-  float bx, by;
   GLuint shader_program = 0;
   static GLuint default_shader_program = 0;
   static GLuint rect_vertex_array = 0;


### PR DESCRIPTION
While at that, also convert uint to unsigned int, as it won't,
otherwise, compile on macOS.

Signed-off-by: Felipe Balbi <felipe@balbi.sh>