### PR TITLE
Enable address sanitizer by default

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -16,7 +16,7 @@ jobs:
           sudo apt-get --no-install-recommends -y install guile-3.0 guile-3.0-dev guile-3.0-libs libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libglfw3 libglfw3-dev mesa-common-dev make pkg-config
 
       - name: Configure
-        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
+        run: cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build
         run: make -C build

--- a/cmake/compiler.cmake
+++ b/cmake/compiler.cmake
@@ -1,5 +1,7 @@
 include(CheckCCompilerFlag)
 
+option(FLUX_USE_ASAN "Use libASAN in the compiled library and binary" ON)
+
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_FLAGS_DEBUG "-O0 -g -ggdb -DDEBUG")
@@ -43,3 +45,8 @@ add_compile_option_if(-Wunused-variable WUNUSED-VARIABLE)
 add_compile_option_if(-fno-delete-null-pointer-checks
   FNO-DELETE-NULL-POINTER-CHECKS)
 add_compile_option_if(-fno-strict-overflow FNO-STRICT-OVERFLOW)
+
+if(FLUX_USE_ASAN)
+add_compile_options(-fsanitize=address)
+add_link_options(-fsanitize=address)
+endif()


### PR DESCRIPTION
This PR introduces a new option called `FLUX_USE_ASAN` to enable the inclusion of `libasan` in the project. It's by default enabled and can get disabled via `cmake -DFLUX_USE_ASAN=OFF`.

The PR also uses `RelWithDebInfo` for the GitHub workflow, as debugging symbols (and thus call stacks) are really helpful on the log.

Unfortunately, this PR also uncovers an issue within `flux_vector_push` or the accompanying tests.