### PR TITLE
Add brackets around declarations in switch

### DIFF
--- a/lib/mesche/src/object.c
+++ b/lib/mesche/src/object.c
@@ -132,10 +132,12 @@ void mesche_object_free(Object *object) {
     FREE(ObjectFunction, object);
     break;
   case ObjectKindClosure:
-    ObjectClosure *closure = (ObjectClosure*)object;
-    FREE_ARRAY(ObjectUpvalue *, closure->upvalues, closure->upvalue_count);
-    FREE(ObjectFunction, object);
-    break;
+    {
+      ObjectClosure *closure = (ObjectClosure*)object;
+      FREE_ARRAY(ObjectUpvalue *, closure->upvalues, closure->upvalue_count);
+      FREE(ObjectFunction, object);
+      break;
+    }
   case ObjectKindNativeFunction:
     FREE(ObjectNativeFunction, object);
     break;


### PR DESCRIPTION
I found these issues in the latest `build` runs, see https://github.com/FluxHarmonic/flux-compose/runs/5195798221?check_suite_focus=true#step:5:23