### PR TITLE
Run mesche examples automatically in CI

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: Test
         run: ./build/run-tests
 
+      - name: Test Mesche Examples
+        run: find lib/mesche/samples -type f -print -exec ./build/flux-compose "{}" \;
+
       - name: Archive workflow results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Ensures that the mesche examples stay runnable :)